### PR TITLE
Handle cursor fetch calls before execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL=/bin/bash
 
 lint:
-	ruff .
+ruff check .
 
 test: lint
 	python ./test/test.py -v

--- a/aurora_data_api/__init__.py
+++ b/aurora_data_api/__init__.py
@@ -395,10 +395,12 @@ class AuroraDataAPICursor:
                 yield record
 
     def fetchone(self):
+        if self._iterator is None:
+            raise InterfaceError("No results to fetch")
         try:
             return next(self._iterator)
         except StopIteration:
-            pass
+            return None
 
     def fetchmany(self, size=None):
         if size is None:
@@ -413,6 +415,8 @@ class AuroraDataAPICursor:
         return results
 
     def fetchall(self):
+        if self._iterator is None:
+            raise InterfaceError("No results to fetch")
         return list(self._iterator)
 
     def setinputsizes(self, sizes):


### PR DESCRIPTION
## Summary
- raise `InterfaceError` when fetching before executing a query
- update Makefile to use `ruff check` for linting

## Testing
- `ruff check .`
- `python ./test/test.py -v` *(fails: You must specify a region)*

------
https://chatgpt.com/codex/tasks/task_b_68a6614e2aa883248f775e6d03f736e7